### PR TITLE
Adding arrows to active migrations with map

### DIFF
--- a/lib/logger.bash
+++ b/lib/logger.bash
@@ -26,7 +26,7 @@ Logger_log() {
     if [ $Logger__has_prefix -eq 1 ]; then
         echo "<< $Logger__prefix >>: $1"
     else
-        echo $1
+        echo "$1"
     fi
 
     # Disabling color (if param is passed)
@@ -55,7 +55,7 @@ Logger__prompt() {
     if [ $Logger__has_prefix -eq 1 ]; then
         echo -n "<< $Logger__prefix >>: $1"
     else
-        echo -n $1
+        echo -n "$1"
     fi
 }
 

--- a/modules/migrate/lib/migrate.bash
+++ b/modules/migrate/lib/migrate.bash
@@ -310,11 +310,11 @@ Migrate_step_up() {
 Migrate_handle_single_map() {
     # If migration is active
     if [ "$2" -eq 1 ]; then
-        Logger__alert "$1"
+        Logger__alert "> $1"
 
     # Migration is not active
     else
-        Logger__log "$1"
+        Logger__log "  $1"
     fi
 }
 


### PR DESCRIPTION
Adds arrows to `migrate:map` for both readability and also to support terminals without full color support.

```
> 1414870746_create_person_table
> 1415409100_create_foo_table
> 1415409339_create_bar_table
  1415409516_create_baz_table
  1415409523_create_tizz_table
```

Also quoting some unquoted variables in logger
